### PR TITLE
WL-3215 Upgrade the rest of ROME.

### DIFF
--- a/news-impl/impl/pom.xml
+++ b/news-impl/impl/pom.xml
@@ -67,9 +67,9 @@
       <version>2.0.0-alpha-ox1</version>
     </dependency>
     <dependency>
-      <groupId>rome</groupId>
+      <groupId>com.rometools</groupId>
       <artifactId>rome-fetcher</artifactId>
-      <version>1.0</version>
+      <version>2.0.0-alpha-ox1</version>
     </dependency>
     <dependency>
       <groupId>com.rometools</groupId>

--- a/news-impl/impl/src/java/org/sakaiproject/news/impl/BasicNewsChannel.java
+++ b/news-impl/impl/src/java/org/sakaiproject/news/impl/BasicNewsChannel.java
@@ -49,8 +49,8 @@ import com.sun.syndication.feed.synd.SyndEnclosure;
 import com.sun.syndication.feed.synd.SyndEntry;
 import com.sun.syndication.feed.synd.SyndFeed;
 import com.sun.syndication.feed.synd.SyndImage;
-import com.sun.syndication.fetcher.FeedFetcher;
-import com.sun.syndication.fetcher.impl.HttpURLFeedFetcher;
+import org.rometools.fetcher.FeedFetcher;
+import org.rometools.fetcher.impl.HttpURLFeedFetcher;
 import com.sun.syndication.io.ParsingFeedException;
 
 /***********************************************************************************


### PR DESCRIPTION
This stops the news tool breaking on some deployments because it had 2 copies of rome on it's classpath and depending on directory sorting depended on what got used.
